### PR TITLE
feat: add `@Diverge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ The library was developed out of necessity for the [Quarkdown typesetting system
 it's currently available only for Kotlin/JVM, though Kotlin Multiplatform would be easy to support.  
 Contributions towards multiplatform support are welcome.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Deep-copying data classes](#deep-copying-data-classes)
+- [Merging data classes](#merging-data-classes)
+- [Diverging classes](#diverging-classes)
+- [Troubleshooting](#troubleshooting)
+
 ## Installation
 
 ```kotlin
@@ -137,6 +145,29 @@ fun main() {
     val preferences: Preferences = user.merge(default)
     println(preferences) // Preferences(theme=dark, fontSize=16, autoSaveDelay=10)
 }
+```
+
+&nbsp;
+
+## Diverging classes
+
+Annotating a class or its constructor parameters with `@Diverge` will provide a `diverge` function, similar to a data class's `copy`, but available on non-data classes and exposing only the marked parameters.
+
+This is useful when you need a `copy`-like function but can't make the class a full `data class`.
+
+```kotlin
+import com.quarkdown.amber.annotations.Diverge
+
+class Person(
+    val name: String,
+    @Diverge val age: Int,
+    @Diverge val city: String,
+)
+
+val person = Person("Alice", 30, "New York")
+val p1 = alice.diverge(age = 31)                  // Person(name=Alice, age=31, city=New York)
+val p2 = alice.diverge(age = 31, city = "Boston") // Person(name=Alice, age=31, city=Boston)
+val p3 = alice.diverge(name = "Bob")              // Error: 'name' is not marked with @Diverge
 ```
 
 &nbsp;

--- a/annotations/src/main/kotlin/com/quarkdown/amber/annotations/Diverge.kt
+++ b/annotations/src/main/kotlin/com/quarkdown/amber/annotations/Diverge.kt
@@ -1,0 +1,47 @@
+package com.quarkdown.amber.annotations
+
+/**
+ * Marks one or more primary-constructor parameters of a class as "divergeable" — i.e.,
+ * exposed as parameters of a generated `diverge(...)` extension that returns a copy of
+ * the receiver with the marked parameters replaced.
+ *
+ * Behaviour is similar to a data class `copy(...)`, but works on any class (not just data
+ * classes) and only the *marked* parameters appear in the generated function's signature.
+ *
+ * Placement:
+ * - On a single constructor parameter: only that parameter is divergeable.
+ *   `class Person(val name: String, @Diverge val age: Int)`
+ * - On the primary constructor: every parameter is divergeable.
+ *   `class Person @Diverge constructor(val name: String, val age: Int)`
+ * - On the class itself: every parameter of the primary constructor is divergeable.
+ *   `@Diverge class Person(val name: String, val age: Int)`
+ *
+ * What gets generated, given marked parameters `p1, p2`:
+ * ```
+ * fun <ClassName>.diverge(
+ *     p1: P1 = this.p1,
+ *     p2: P2 = this.p2,
+ * ): <ClassName> = <ClassName>(
+ *     // all primary-ctor params, marked or not — non-marked ones come from `this`
+ * )
+ * ```
+ *
+ * Calling `.diverge()` with no arguments returns a structural copy of the receiver.
+ *
+ * Constraints:
+ * - The class must have a primary constructor.
+ * - All primary-constructor parameters must be declared `val` or `var`, since the
+ *   generator needs to read each value from `this` to reconstruct.
+ * - When applied on a constructor, that constructor must be the primary one.
+ *
+ * Notes:
+ * - Annotation retention is SOURCE; it does not exist at runtime.
+ * - The generated file is `<ClassName>_Diverge.kt` in the class's package.
+ */
+@Target(
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.CLASS,
+)
+@Retention(AnnotationRetention.SOURCE)
+annotation class Diverge

--- a/processor/src/main/kotlin/com/quarkdown/amber/processor/AnnotationProcessor.kt
+++ b/processor/src/main/kotlin/com/quarkdown/amber/processor/AnnotationProcessor.kt
@@ -1,72 +1,34 @@
 package com.quarkdown.amber.processor
 
-import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.KSAnnotated
-import com.google.devtools.ksp.validate
 import com.quarkdown.amber.processor.generator.SourceGenerator
-import com.quarkdown.amber.processor.generator.writeFile
 import kotlin.reflect.KClass
 
 /**
- * Base KSP SymbolProcessor for annotations handled by this module.
+ * KSP processor for the simple "one annotated symbol -> one generated file" shape.
  *
- * This processor locates symbols annotated with the provided [annotation], validates each symbol
- * via [validate], and delegates source generation to a [SourceGenerator] created by
- * [generatorProvider]. Implementations only need to provide the validation logic and the concrete
- * generator.
+ * For each symbol carrying [annotation], [validate] coerces it to the expected type [T]
+ * (or throws to abort that one symbol), then [generatorProvider] builds the per-symbol
+ * source generator. Errors are reported via KSP's logger; KSP-deferred symbols are
+ * returned for retry in a later round.
  *
- * @param T The specific KSP annotated type this processor accepts (e.g., KSClassDeclaration).
- * @param environment KSP-provided environment with logger and code generator.
- * @param annotation The annotation class to search for.
- * @param generatorProvider Factory that builds a [SourceGenerator] for a validated symbol.
+ * Use this when each annotated symbol stands on its own. For processors that need to
+ * group multiple symbols into one file, extend [AnnotationProcessorBase] directly.
  */
 abstract class AnnotationProcessor<T : KSAnnotated>(
     environment: SymbolProcessorEnvironment,
     annotation: KClass<out Annotation>,
     private val generatorProvider: (T) -> SourceGenerator<T>,
-) : SymbolProcessor {
-    /** Logger for reporting errors and info during processing. */
-    private val logger: KSPLogger = environment.logger
-
-    /** Fully-qualified name of the processed annotation. */
-    private val annotationFullyQualifiedName: String = annotation.java.run { "$packageName.$simpleName" }
-
-    /** Simple (unqualified) name of the processed annotation. */
-    private val annotationSimpleName: String = annotation.java.simpleName
-
-    /**
-     * Entry point called by KSP in each round.
-     *
-     * Returns the list of symbols that couldn't be validated in this round so KSP can revisit
-     * them later, as per its standard contract.
-     */
-    override fun process(resolver: Resolver): List<KSAnnotated> {
-        val symbols = resolver.getSymbolsWithAnnotation(annotationFullyQualifiedName)
-        val unableToProcess = mutableListOf<KSAnnotated>()
-
-        for (symbol in symbols) {
-            if (!symbol.validate()) {
-                unableToProcess.add(symbol)
-                continue
-            }
-
-            val annotated: T =
-                try {
-                    this.validate(symbol)
-                } catch (e: Exception) {
-                    logger.error("Failed to process @$annotationSimpleName: ${e.message}", symbol)
-                    continue
-                }
-
-            val generator = generatorProvider(annotated)
-            val source = generator.generateSource()
-            generator.writeFile(source)
+) : AnnotationProcessorBase(environment, annotation) {
+    final override fun process(resolver: Resolver): List<KSAnnotated> {
+        val (valid, deferred) = partitionSymbols(resolver)
+        for (symbol in valid) {
+            val annotated = guarded(symbol) { validate(symbol) } ?: continue
+            guarded(symbol) { emit(generatorProvider(annotated)) }
         }
-
-        return unableToProcess
+        return deferred
     }
 
     /** Ensure [annotated] is of the expected type and shape; return the casted/validated value. */

--- a/processor/src/main/kotlin/com/quarkdown/amber/processor/AnnotationProcessorBase.kt
+++ b/processor/src/main/kotlin/com/quarkdown/amber/processor/AnnotationProcessorBase.kt
@@ -1,0 +1,58 @@
+package com.quarkdown.amber.processor
+
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.validate
+import com.quarkdown.amber.processor.generator.SourceGenerator
+import com.quarkdown.amber.processor.generator.writeFile
+import kotlin.reflect.KClass
+
+/**
+ * Shared infrastructure for KSP processors focused on a single annotation type.
+ *
+ * Sits between [SymbolProcessor] and the more opinionated [AnnotationProcessor]: it owns
+ * the annotation's FQN/name lookup, the logger, and the helpers that subclasses use to
+ * partition symbols by KSP's [validate] gate, run risky work with structured error
+ * reporting, and write a generator's output.
+ *
+ * Subclasses implement [process] freely — typical shapes are one-symbol-per-file
+ * (see [AnnotationProcessor]) or many-symbols-grouped-by-class.
+ */
+abstract class AnnotationProcessorBase(
+    protected val environment: SymbolProcessorEnvironment,
+    annotation: KClass<out Annotation>,
+) : SymbolProcessor {
+    protected val logger: KSPLogger = environment.logger
+
+    private val annotationName: String = annotation.java.simpleName
+    private val annotationFqn: String = annotation.java.run { "$packageName.$simpleName" }
+
+    /**
+     * Partition this round's annotated symbols into (valid, deferred). Deferred symbols
+     * should be returned from [process] so KSP revisits them next round.
+     */
+    protected fun partitionSymbols(resolver: Resolver): Pair<List<KSAnnotated>, List<KSAnnotated>> =
+        resolver.getSymbolsWithAnnotation(annotationFqn).partition { it.validate() }
+
+    /**
+     * Run [block] and return its result, or null if it throws. Exceptions are reported
+     * via [KSPLogger.error] anchored on [node] (typically the symbol being processed) so
+     * KSP surfaces them as compilation errors rather than crashing the round.
+     */
+    protected fun <T> guarded(node: KSNode?, block: () -> T): T? =
+        try {
+            block()
+        } catch (e: Exception) {
+            logger.error("Failed to process @$annotationName: ${e.message}", node)
+            null
+        }
+
+    /** Write the generator's source to its destination file. */
+    protected fun emit(generator: SourceGenerator<*>) {
+        generator.writeFile(generator.generateSource())
+    }
+}

--- a/processor/src/main/kotlin/com/quarkdown/amber/processors/diverge/DivergeProcessor.kt
+++ b/processor/src/main/kotlin/com/quarkdown/amber/processors/diverge/DivergeProcessor.kt
@@ -1,0 +1,71 @@
+package com.quarkdown.amber.processors.diverge
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.quarkdown.amber.annotations.Diverge
+import com.quarkdown.amber.processor.AnnotationProcessorBase
+
+/**
+ * KSP processor for [Diverge].
+ *
+ * Normalises every annotated symbol into a set of marked primary-constructor parameter
+ * names per class:
+ * - `@Diverge` on a value parameter -> that parameter is marked.
+ * - `@Diverge` on the primary constructor -> all its parameters are marked.
+ * - `@Diverge` on the class -> all primary-constructor parameters are marked.
+ *
+ * For each class with at least one mark, generates `<ClassName>_Diverge.kt`.
+ */
+class DivergeProcessor(
+    environment: SymbolProcessorEnvironment,
+) : AnnotationProcessorBase(environment, Diverge::class) {
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val (valid, deferred) = partitionSymbols(resolver)
+
+        val markedParamsByClass = LinkedHashMap<KSClassDeclaration, MutableSet<String>>()
+        for (symbol in valid) {
+            val target = guarded(symbol) { resolveTarget(symbol) } ?: continue
+            markedParamsByClass.getOrPut(target.first) { linkedSetOf() } += target.second
+        }
+
+        for ((cls, params) in markedParamsByClass) {
+            guarded(cls) { emit(DivergeSourceGenerator(environment, cls, params)) }
+        }
+
+        return deferred
+    }
+
+    private fun resolveTarget(symbol: KSAnnotated): Pair<KSClassDeclaration, Set<String>> =
+        when (symbol) {
+            is KSValueParameter -> {
+                val ctor = symbol.parent as? KSFunctionDeclaration
+                    ?: error("a value parameter must live inside a primary constructor")
+                ctor.requirePrimaryConstructorClass() to setOf(symbol.name!!.asString())
+            }
+            is KSFunctionDeclaration -> {
+                symbol.requirePrimaryConstructorClass() to symbol.parameters.allParamNames()
+            }
+            is KSClassDeclaration -> {
+                val ctor = symbol.primaryConstructor
+                    ?: error("class ${symbol.qualifiedName?.asString()} has no primary constructor")
+                symbol to ctor.parameters.allParamNames()
+            }
+            else -> error("unsupported annotation target: ${symbol::class.simpleName}")
+        }
+
+    private fun KSFunctionDeclaration.requirePrimaryConstructorClass(): KSClassDeclaration {
+        val cls = parentDeclaration as? KSClassDeclaration
+            ?: error("a constructor must be declared inside a class")
+        require(this == cls.primaryConstructor) {
+            "@Diverge must target the primary constructor of ${cls.qualifiedName?.asString()}"
+        }
+        return cls
+    }
+
+    private fun List<KSValueParameter>.allParamNames(): Set<String> =
+        mapNotNull { it.name?.asString() }.toSet()
+}

--- a/processor/src/main/kotlin/com/quarkdown/amber/processors/diverge/DivergeProcessorProvider.kt
+++ b/processor/src/main/kotlin/com/quarkdown/amber/processors/diverge/DivergeProcessorProvider.kt
@@ -1,0 +1,12 @@
+package com.quarkdown.amber.processors.diverge
+
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+
+/**
+ * Registers [DivergeProcessor] with KSP.
+ */
+class DivergeProcessorProvider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor = DivergeProcessor(environment)
+}

--- a/processor/src/main/kotlin/com/quarkdown/amber/processors/diverge/DivergeSourceGenerator.kt
+++ b/processor/src/main/kotlin/com/quarkdown/amber/processors/diverge/DivergeSourceGenerator.kt
@@ -1,0 +1,73 @@
+package com.quarkdown.amber.processors.diverge
+
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.quarkdown.amber.processor.GenerationConstants.INDENT
+import com.quarkdown.amber.processor.generator.ClassSourceGenerator
+import com.quarkdown.amber.processor.utils.formattedName
+
+/** Name of the generated extension function. */
+private const val DIVERGE_FUNCTION_NAME: String = "diverge"
+
+/**
+ * Generates the diverge extension for a class with one or more `@Diverge`-marked
+ * primary-constructor parameters.
+ *
+ * For `class Person(val name: String, @Diverge val age: Int)` produces:
+ * ```
+ * fun Person.diverge(
+ *     age: kotlin.Int = this.age,
+ * ): Person = Person(
+ *     name = this.name,
+ *     age = age,
+ * )
+ * ```
+ */
+class DivergeSourceGenerator(
+    environment: SymbolProcessorEnvironment,
+    annotated: KSClassDeclaration,
+    private val markedParams: Set<String>,
+) : ClassSourceGenerator(environment, annotated) {
+    override val fileNameSuffix: String
+        get() = "Diverge"
+
+    override fun generateSourceBody(annotated: KSClassDeclaration): String {
+        val ctor = annotated.primaryConstructor
+            ?: error("class ${annotated.qualifiedName?.asString()} has no primary constructor")
+        val ctorParams = ctor.parameters
+        val nonProperty = ctorParams.filterNot { it.isVal || it.isVar }
+        require(nonProperty.isEmpty()) {
+            "all primary-constructor parameters of ${annotated.qualifiedName?.asString()} must be 'val' or 'var' " +
+                "(non-property params: ${nonProperty.mapNotNull { it.name?.asString() }})"
+        }
+
+        val className = annotated.simpleName.asString()
+        val signature = ctorParams
+            .filter { it.name!!.asString() in markedParams }
+            .joinToString(separator = "") { it.signatureLine() }
+        val ctorArgs = ctorParams.joinToString(separator = "") { it.callArgLine() }
+
+        return buildString {
+            appendLine("fun $className.$DIVERGE_FUNCTION_NAME(")
+            append(signature)
+            appendLine("): $className = $className(")
+            append(ctorArgs)
+            append(")")
+        }
+    }
+
+    private fun KSValueParameter.signatureLine(): String {
+        val name = name!!.asString()
+        return "$INDENT$name: ${type.resolve().renderNullable()} = this.$name,\n"
+    }
+
+    private fun KSValueParameter.callArgLine(): String {
+        val name = name!!.asString()
+        val rhs = if (name in markedParams) name else "this.$name"
+        return "$INDENT$name = $rhs,\n"
+    }
+}
+
+private fun KSType.renderNullable(): String = if (isMarkedNullable) "$formattedName?" else formattedName

--- a/processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,2 +1,3 @@
 com.quarkdown.amber.processors.mergeable.MergeableProcessorProvider
 com.quarkdown.amber.processors.nesteddata.NestedDataProcessorProvider
+com.quarkdown.amber.processors.diverge.DivergeProcessorProvider

--- a/test/src/test/kotlin/com/quarkdown/amber/processors/diverge/DivergeMultiplePropsTest.kt
+++ b/test/src/test/kotlin/com/quarkdown/amber/processors/diverge/DivergeMultiplePropsTest.kt
@@ -1,0 +1,31 @@
+package com.quarkdown.amber.processors.diverge
+
+import com.quarkdown.amber.annotations.Diverge
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Point(
+    @Diverge val x: Int,
+    @Diverge val y: Int,
+    val label: String,
+)
+
+class DivergeMultiplePropsTest {
+    @Test
+    fun `diverge one marked param at a time`() {
+        val point = Point(x = 1, y = 2, label = "origin")
+        val movedX = point.diverge(x = 10)
+        assertEquals(10, movedX.x)
+        assertEquals(2, movedX.y)
+        assertEquals("origin", movedX.label)
+    }
+
+    @Test
+    fun `diverge multiple marked params at once`() {
+        val point = Point(x = 1, y = 2, label = "origin")
+        val moved = point.diverge(x = 10, y = 20)
+        assertEquals(10, moved.x)
+        assertEquals(20, moved.y)
+        assertEquals("origin", moved.label)
+    }
+}

--- a/test/src/test/kotlin/com/quarkdown/amber/processors/diverge/DivergeNullableTest.kt
+++ b/test/src/test/kotlin/com/quarkdown/amber/processors/diverge/DivergeNullableTest.kt
@@ -1,0 +1,36 @@
+package com.quarkdown.amber.processors.diverge
+
+import com.quarkdown.amber.annotations.Diverge
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class Labeled(
+    @Diverge val label: String?,
+    val id: Int,
+)
+
+class DivergeNullableTest {
+    @Test
+    fun `diverge replaces null with a value`() {
+        val labeled = Labeled(label = null, id = 1)
+        val updated = labeled.diverge(label = "named")
+        assertEquals("named", updated.label)
+        assertEquals(1, updated.id)
+    }
+
+    @Test
+    fun `diverge accepts null override`() {
+        val labeled = Labeled(label = "named", id = 1)
+        val updated = labeled.diverge(label = null)
+        assertNull(updated.label)
+    }
+
+    @Test
+    fun `diverge with no args preserves null`() {
+        val labeled = Labeled(label = null, id = 1)
+        val copy = labeled.diverge()
+        assertNull(copy.label)
+        assertEquals(1, copy.id)
+    }
+}

--- a/test/src/test/kotlin/com/quarkdown/amber/processors/diverge/DivergeOnClassTest.kt
+++ b/test/src/test/kotlin/com/quarkdown/amber/processors/diverge/DivergeOnClassTest.kt
@@ -1,0 +1,29 @@
+package com.quarkdown.amber.processors.diverge
+
+import com.quarkdown.amber.annotations.Diverge
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Diverge
+class Config(
+    val host: String,
+    val port: Int,
+)
+
+class DivergeOnClassTest {
+    @Test
+    fun `class-level diverge marks every param`() {
+        val config = Config(host = "localhost", port = 8080)
+        val updated = config.diverge(port = 9090)
+        assertEquals("localhost", updated.host)
+        assertEquals(9090, updated.port)
+    }
+
+    @Test
+    fun `class-level diverge with no args returns equal copy`() {
+        val config = Config(host = "localhost", port = 8080)
+        val copy = config.diverge()
+        assertEquals(config.host, copy.host)
+        assertEquals(config.port, copy.port)
+    }
+}

--- a/test/src/test/kotlin/com/quarkdown/amber/processors/diverge/DivergeOnConstructorTest.kt
+++ b/test/src/test/kotlin/com/quarkdown/amber/processors/diverge/DivergeOnConstructorTest.kt
@@ -1,0 +1,30 @@
+package com.quarkdown.amber.processors.diverge
+
+import com.quarkdown.amber.annotations.Diverge
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Box
+    @Diverge
+    constructor(
+        val width: Int,
+        val height: Int,
+    )
+
+class DivergeOnConstructorTest {
+    @Test
+    fun `constructor-level diverge marks every param`() {
+        val box = Box(width = 10, height = 20)
+        val resized = box.diverge(width = 100, height = 200)
+        assertEquals(100, resized.width)
+        assertEquals(200, resized.height)
+    }
+
+    @Test
+    fun `constructor-level diverge supports partial override`() {
+        val box = Box(width = 10, height = 20)
+        val taller = box.diverge(height = 999)
+        assertEquals(10, taller.width)
+        assertEquals(999, taller.height)
+    }
+}

--- a/test/src/test/kotlin/com/quarkdown/amber/processors/diverge/DivergeTest.kt
+++ b/test/src/test/kotlin/com/quarkdown/amber/processors/diverge/DivergeTest.kt
@@ -1,0 +1,31 @@
+package com.quarkdown.amber.processors.diverge
+
+import com.quarkdown.amber.annotations.Diverge
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Person(
+    val name: String,
+    @Diverge val age: Int,
+    val city: String,
+)
+
+class DivergeTest {
+    @Test
+    fun `diverges only the marked param`() {
+        val person = Person("Alice", 30, "New York")
+        val updated = person.diverge(age = 31)
+        assertEquals("Alice", updated.name)
+        assertEquals(31, updated.age)
+        assertEquals("New York", updated.city)
+    }
+
+    @Test
+    fun `diverge with no args returns equal copy`() {
+        val person = Person("Alice", 30, "New York")
+        val copy = person.diverge()
+        assertEquals(person.name, copy.name)
+        assertEquals(person.age, copy.age)
+        assertEquals(person.city, copy.city)
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README with a new “Table of contents” and a “Diverging classes” section explaining `@Diverge`, the generated `diverge(...)` extension, and common error cases.

* **New Features**
  * Introduced `@Diverge` to generate a `<ClassName>.diverge(...)` extension that creates a structural copy while letting you override only marked primary-constructor properties (at parameter, constructor, or class level).

* **Tests**
  * Added unit tests covering multiple parameters, nullability, class-level and constructor-level behavior, and generic/bounded generic cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->